### PR TITLE
Shade scala-logging dependency for databricks branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,14 +25,14 @@ test in assembly := {}
 
 assemblyShadeRules in assembly := {
   val shadePackage = "geotrellis.sdg.shaded"
-  val gtVersion = "2.0.0"
+  val gtVersion = "2.1.0"
   Seq(
     ShadeRule.rename("com.fasterxml.jackson.**" -> s"$shadePackage.com.fasterxml.jackson.@1")
       .inLibrary("com.networknt" % "json-schema-validator" % "0.1.7").inAll,
     ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
       .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % gtVersion).inAll,
     ShadeRule.rename("com.typesafe.scalalogging.**" -> s"$shadePackage.com.typesafe.scalalogging.@1")
-      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-spark" % gtVersion).inAll
+      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-vector" % gtVersion).inProject
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,9 @@ assemblyShadeRules in assembly := {
     ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
       .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % gtVersion).inAll,
     ShadeRule.rename("com.typesafe.scalalogging.**" -> s"$shadePackage.com.typesafe.scalalogging.@1")
-      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-vector" % gtVersion).inProject
+      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-vector" % gtVersion).inProject,
+    ShadeRule.rename("com.trueaccord.scalapb.**" -> s"$shadePackage.com.trueaccord.scalapb.@1")
+      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-vectortile" % gtVersion).inProject
   )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("net.pishen" % "sbt-lighter" % "1.2.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")


### PR DESCRIPTION
With these changes applied and compiled into a fat JAR pushed to DataBricks, the `cannot find WKT/logging` error appears to be addressed.

It was replaced with compilation errors in one notebook that involve a namespace conflict between `scala.collections.Iterable` and `com.typesafe.scalalogging.Iterable` when `com.typesafe.scalalogging._` is imported -- the compiler isn't choosing one consistently when we use the `Iterable` type in code. But I believe that's a separate problem and I was able to work around by on explicitly importing the scalalogging items I needed.

The JAR built with the HEAD of this branch is currently attached to the `azavea-geotrellis` cluster in DataBricks. 

edit 1: Updated by @jbouffard to include a shading rule for protobuf in geotrellis-vectortile as well since we need this to avoid dependency conflicts when writing vector tiles on DataBricks.