### PR TITLE
Road Mask CLI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,11 @@ organization := "geotrellis"
 
 libraryDependencies ++= Seq(
   //"org.locationtech.geotrellis" %% "geotrellis-shapefile" % "2.0.0",
+  "org.xerial" % "sqlite-jdbc" % "3.28.0",
   "com.azavea" %% "osmesa" % "0.3.0",
   "com.azavea" %% "osmesa-common" % "0.3.0",
-  "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
-  "org.apache.spark" %% "spark-hive" % "2.3.2" % "provided"//,
+  "org.apache.spark" %% "spark-core" % "2.3.2", //% "provided",
+  "org.apache.spark" %% "spark-hive" % "2.3.2", //% "provided"//,
   //"org.apache.spark" %% "spark-sql" % "2.3.2",// % "provided"//,
   //"com.monovore" %% "decline" % "0.5.0"
 )

--- a/src/main/scala/GeomDataReader.scala
+++ b/src/main/scala/GeomDataReader.scala
@@ -1,0 +1,148 @@
+package geotrellis.sdg
+
+import geotrellis.proj4._
+import geotrellis.proj4.util._
+import geotrellis.vector.{Extent, Geometry}
+import geotrellis.vector.reproject._
+import geotrellis.vectortile._
+import geotrellis.spark._
+import geotrellis.spark.io.kryo._
+import geotrellis.spark.tiling._
+
+import org.locationtech.geomesa.spark.jts._
+import org.locationtech.geomesa.spark.jts.udf.GeometricConstructorFunctions
+
+import com.vividsolutions.jts.geom.{Geometry => JTSGeometry}
+
+import org.apache.commons.io.IOUtils
+
+import org.apache.spark.sql.{SQLContext, DataFrame}
+//import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.{udf, explode}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.net.URI
+import java.util.zip.GZIPInputStream
+
+
+object GeomDataReader {
+  def readAndFormat(targetPath: String, sqlContext: SQLContext, transform: MapKeyTransform): DataFrame = {
+
+    // This DataFrame contains the vector tile data
+    val tileDataFrame: DataFrame =
+      sqlContext
+        .read
+        .format("jdbc")
+        .options(
+          Map(
+            "url" -> s"jdbc:sqlite:$targetPath",
+            "driver" -> "org.sqlite.JDBC",
+            "dbtable" -> "tiles"
+          )
+        ).load()
+
+    // The data is sotred as pbf files, which are gziped vectortiles.
+    // So we need to decompress the bytes in order to read them in.
+    val decompressBytes: (Array[Byte]) => Array[Byte] =
+      (compressedBytes: Array[Byte]) => {
+        val stream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))
+        val output = new ByteArrayOutputStream()
+
+        val result = {
+          IOUtils.copy(stream, output)
+          output.toByteArray
+        }
+
+        stream.close
+        output.close
+
+        result
+      }
+
+    val decompressBytesUDF = udf(decompressBytes)
+
+    val uncompressedTileData: DataFrame =
+      tileDataFrame.withColumn("uncompressed_data", decompressBytesUDF(tileDataFrame.col("tile_data")))
+
+    val produceData: (Array[Byte], Int, Int) => Array[(JTSGeometry, String, String, String)] =
+      (bytes: Array[Byte], col: Int, row: Int) => {
+        val tileExtent: Extent = transform(col, row)
+
+        val vectorTile = VectorTile.fromBytes(bytes, tileExtent)
+
+        vectorTile.toIterable.toArray.map { feat =>
+          val featureType = feat.data.get("@type").get.asInstanceOf[VString].value
+
+          val roadType =
+            feat.data.get("highway") match {
+              case Some(value) => value.asInstanceOf[VString].value
+              case None => null
+            }
+
+          val surfaceType =
+            feat.data.get("surface") match {
+              case Some(value) => value.asInstanceOf[VString].value
+              case None => null
+            }
+
+          (feat.geom.jtsGeom, featureType, roadType, surfaceType)
+        }
+      }
+
+    val produceDataUDF = udf(produceData)
+
+    val geomDataFrame =
+      uncompressedTileData
+        .withColumn(
+          "geom_data",
+          produceDataUDF(
+            uncompressedTileData.col("uncompressed_data"),
+            uncompressedTileData.col("tile_column"),
+            uncompressedTileData.col("tile_row")
+          )
+        )
+
+    val explodedDataFrame =
+      geomDataFrame
+        .withColumn("data", explode(geomDataFrame.col("geom_data")))
+        .select("zoom_level", "tile_column", "tile_row", "data.*")
+        .withColumnRenamed("_1", "geom")
+        .withColumnRenamed("_2", "type")
+        .withColumnRenamed("_3", "roadType")
+        .withColumnRenamed("_4", "surfaceType")
+
+    val isValid: (JTSGeometry) => Boolean = (jtsGeom: JTSGeometry) => jtsGeom.isValid()
+
+    val isValidUDF = udf(isValid)
+
+    val filteredDataFrame: DataFrame =
+      explodedDataFrame
+        .where(
+          isValidUDF(explodedDataFrame("geom")) &&
+          explodedDataFrame("type") === "way" &&
+          (explodedDataFrame("roadType").isNotNull && explodedDataFrame("surfaceType").isNotNull)
+        )
+
+    val bufferGeom: (JTSGeometry) => JTSGeometry =
+      (geom: JTSGeometry) => {
+        val latLngTransform = Transform(WebMercator, LatLng)
+        val latLngGeom = Reproject(Geometry(geom), latLngTransform)
+
+        val center = latLngGeom.jtsGeom.getCentroid()
+        val x = center.getX()
+        val y = center.getY()
+
+        val utmCRS = UTM.getZoneCrs(x, y)
+        val utmTransform = Transform(WebMercator, utmCRS)
+
+        val utmGeom = Reproject(Geometry(geom), utmTransform)
+
+        utmGeom.jtsGeom.buffer(2.0)
+      }
+
+    val bufferGeomUDF = udf(bufferGeom)
+
+    filteredDataFrame
+      .withColumn("bufferGeom", filteredDataFrame.col("geom"))
+  }
+}

--- a/src/main/scala/ProduceRoadMask.scala
+++ b/src/main/scala/ProduceRoadMask.scala
@@ -1,0 +1,66 @@
+package geotrellis.sdg
+
+import geotrellis.raster._
+import geotrellis.raster.rasterize._
+import geotrellis.vector.{Extent, Geometry, Feature}
+import geotrellis.vectortile._
+import geotrellis.proj4._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.cog._
+import geotrellis.spark.io.index.ZCurveKeyIndexMethod
+import geotrellis.spark.io.kryo._
+import geotrellis.spark.partition.SpacePartitioner
+import geotrellis.spark.rasterize._
+import geotrellis.spark.tiling._
+
+import org.locationtech.geomesa.spark.jts._
+//import org.locationtech.geomesa.spark.jts.udf.GeometricConstructorFunctions
+
+import com.vividsolutions.jts.geom.{Geometry => JTSGeometry, Polygon}
+
+import org.apache.commons.io.IOUtils
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.KryoSerializer
+import org.apache.spark.sql._
+
+
+object ProduceRoadMask {
+  def main(args: Array[String]): Unit = {
+    System.setSecurityManager(null)
+
+    val conf =
+      new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Road Mask")
+        .set("spark.serializer", classOf[KryoSerializer].getName)
+        .set("spark.kryo.registrator", classOf[KryoRegistrator].getName)
+        .set("spark.executor.memory", "8g")
+        .set("spark.driver.memory", "8g")
+        .set("spark.default.parallelism", "120")
+        //.set("spark.yarn.am.memory", "8g")
+        //.set("spark.yarn.am.memoryOverhead", "8g")
+        //.set("spark.driver.memoryOverhead", "8g")
+        //.set("spark.executor.memoryOverhead", "6g")
+        //.set("spark.network.timeout", "600")
+        //.set("spark.executor.heartbeatInterval", "100")
+
+    implicit val ss = SparkSession.builder.config(conf).enableHiveSupport.getOrCreate
+    val sqlContext = ss.sqlContext
+
+    ss.withJTS
+
+    try {
+      val transform = MapKeyTransform(WebMercator, 4096, 4096)
+
+      val osmRoads = GeomDataReader.readAndFormat(args(1), sqlContext, transform)
+
+      osmRoads.write.format("orc").save(args(2))
+
+    } finally {
+      ss.sparkContext.stop
+    }
+  }
+}

--- a/src/main/scala/SouthAmericaIngest.scala
+++ b/src/main/scala/SouthAmericaIngest.scala
@@ -47,6 +47,7 @@ import scala.collection.JavaConverters._
 
 
 object SouthAmericaIngest {
+/*
   type VTF[G <: Geometry] = Feature[G, Map[String, VString]]
 
   val southAmericaExtent = Extent(-98.96484375, -57.89149735271031, -28.652343749999996, 15.623036831528264)
@@ -111,7 +112,6 @@ object SouthAmericaIngest {
 
     try {
 
-      /*
       val countries: Seq[MultiPolygonFeature[Map[String, String]]] =
         GeoJsonReader.readFromS3("un-sdg", "south-america/south-america-country-populations-epsg4326.geojson")
       b
@@ -350,7 +350,6 @@ object SouthAmericaIngest {
       val updatedDF: DataFrame = ss.createDataFrame(rowRDD, schema)
 
       updatedDF.write.format("orc").save("s3a://un-sdg/south-america/south-america-road-and-population-data-2015-epsg4326.orc")
-      */
 
       //rowRDD.unpersist()
 
@@ -409,7 +408,6 @@ object SouthAmericaIngest {
 
       //osmData.unpersist()
 
-      /*
       val featuresRDD: RDD[GenerateVT.VTF[Geometry]] =
         updatedRDD.mapValues { case (_, features) =>
           features.map { feature =>
@@ -418,7 +416,6 @@ object SouthAmericaIngest {
             feature.copy(geom = reprojected)
           }
         }.values.flatMap { f => f }
-      */
 
       val targetZoom = 6
       val scheme = ZoomedLayoutScheme(WebMercator)
@@ -431,7 +428,6 @@ object SouthAmericaIngest {
 
       //updatedRDD.unpersist()
 
-      /*
       def produceRDDs(
         rdd: RDD[(SpatialKey, (SpatialKey, GenerateVT.VTF[Geometry]))],
         zoom: Int
@@ -444,9 +440,7 @@ object SouthAmericaIngest {
           List((zoom, rdd))
         else
           List[(Int, RDD[(SpatialKey, (SpatialKey, GenerateVT.VTF[Geometry]))])]()
-        */
 
-       /*
       val rdds = produceRDDs(keyedFeaturesRDD, targetZoom)
 
       rdds.foreach { case (z, vt) =>
@@ -459,7 +453,6 @@ object SouthAmericaIngest {
 
         //vt.unpersist()
       }
-      */
 
       //osmData.unpersist()
 
@@ -501,4 +494,5 @@ object SouthAmericaIngest {
       case e: java.lang.UnsupportedOperationException => 1
     }
   }
+*/
 }


### PR DESCRIPTION
This PR adds the `ProduceRoadMask` CLI that will take a `mbtiles` and produce an `orc` file. This `orc` file contains OSM geometries in two different formats: the first being column `geom` which contains the geometries in the `WebMercator` projection; the other column, `buffered_geom`, contains the geometries that are in a UTM projection and buffered by 2 km. All of the geometries in this file are roads, and in addition to the geometry data itself, road data is also included such as `surface_type` and `road_type`.

Note, this task originally called for a COG layer to be produce, however, after some discussion, it was decided that an `orc` file would be better. See [this](https://github.com/azavea/geotrellis/issues/148#issuecomment-522064372) comment for more information.

This PR resolves: https://github.com/azavea/geotrellis/issues/148