### PR TITLE
Compute forgotten pop vector tile layer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,11 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-spark" % "3.0.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-s3-spark" % "3.0.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-spark-testkit" % "3.0.0-SNAPSHOT",
+  "com.azavea" %% "vectorpipe" % "2.0.0-M1",
   "org.apache.spark" %% "spark-core" % "2.4.1" % Provided,
   "org.apache.spark" %% "spark-hive" % "2.4.1" % Provided,
   "org.locationtech.geomesa" %% "geomesa-spark-jts" % "2.3.0",
+  "org.log4s" %% "log4s" % "1.8.2",
   "org.tpolecat" %% "doobie-core" % "0.5.2",
   "org.xerial" % "sqlite-jdbc" % "3.28.0",
   // "org.geotools" % "gt-geopkg" % "21.2", // GeoTools version currently used by GT 3.0.0-SNAPSHOT
@@ -29,7 +31,8 @@ externalResolvers := Seq(
   "locationtech-releases" at "https://repo.locationtech.org/content/repositories/releases/",
   "locationtech-snapshots" at "https://repo.locationtech.org/content/repositories/snapshots/",
   Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-  Resolver.bintrayRepo("azavea", "geotrellis")
+  Resolver.bintrayRepo("azavea", "geotrellis"),
+  Resolver.bintrayRepo("azavea", "maven")
 )
 
 test in assembly := {}

--- a/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
+++ b/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
@@ -1,0 +1,66 @@
+package geotrellis.sdg
+
+import java.net.URI
+
+import geotrellis.layer._
+import geotrellis.vector.{Extent, Feature, Geometry, Point}
+import geotrellis.vectortile.VDouble
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, expr, udf}
+import vectorpipe.vectortile._
+
+/**
+  * VectorPipe Pipeline to sum the population associated with an x/y coordinate
+  * in the rasterLayoutScheme space. It outputs polygons that have the aggregated
+  * value across all geometries under the polygon as a vector tile layer.
+  *
+  * The vector tile layer in the output is "data" and the population sum is stored
+  * in the property "population" of each polygon geometry.
+  *
+  * The size of the output polygons is determined by the tileSize of the passed
+  * rasterLayoutScheme. Larger tileSize == smaller polygon "pixels".
+  *
+  * This pipeline is fairly generic and could be re-used for any reduction
+  * operation over a single value.
+  */
+case class ForgottenPopPipeline(geometryColumn: String,
+                                baseOutputURI: URI,
+                                rasterLayoutScheme: ZoomedLayoutScheme,
+                                maxZoom: Int) extends Pipeline {
+
+  override val layerMultiplicity: LayerMultiplicity = SingleLayer("data")
+
+  def geomUdf(layout: LayoutDefinition) = udf { (x: Long, y: Long) =>
+    val (xCoord, yCoord) = layout.gridToMap(x, y)
+    Point(xCoord, yCoord)
+  }
+
+  override def reduce(input: DataFrame, layoutLevel: LayoutLevel, keyColumn: String): DataFrame = {
+    // Since we call reduce before we generate VT for a layer, skip reduce on first zoom
+    val reduceUdf = if (layoutLevel.zoom == maxZoom) {
+      udf { c: Long => c }
+    } else {
+      udf { c: Long => c / 2 }
+    }
+    val rasterLayout = rasterLayoutScheme.levelForZoom(layoutLevel.zoom).layout
+    input
+      .select("x", "y", "pop")
+      .withColumn("x", reduceUdf(col("x")))
+      .withColumn("y", reduceUdf(col("y")))
+      .groupBy(col("x"), col("y"))
+      .agg(expr("sum(pop) as pop"))
+      .withColumn("geom", geomUdf(rasterLayout)(col("x"), col("y")))
+      .withColumn(keyColumn, keyTo(layoutLevel.layout)(col("geom")))
+  }
+
+  override def pack(row: Row, zoom: Int): VectorTileFeature[Geometry] = {
+    val pop = row.getAs[Double]("pop")
+    val center = row.getAs[Point]("geom")
+    val layout = rasterLayoutScheme.levelForZoom(zoom).layout
+    val xDistance = layout.cellSize.width
+    val yDistance = layout.cellSize.height
+    val geom = Extent(center.getX - xDistance / 2, center.getY - yDistance / 2,
+                      center.getX + xDistance / 2, center.getY + yDistance / 2).toPolygon
+    Feature(geom, Map("population" -> VDouble(pop)))
+  }
+}

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -6,30 +6,23 @@ import geotrellis.qatiles.{OsmQaTiles, RoadTags}
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.compression.DeflateCompression
-import geotrellis.raster.io.geotiff.tags.codes.CompressionType
 import geotrellis.raster.io.geotiff.{GeoTiffBuilder, GeoTiffOptions, SinglebandGeoTiff, Tags, Tiled}
 import geotrellis.spark.{ContextRDD, TileLayerRDD}
 import geotrellis.vector._
 import geotrellis.vectortile.VectorTile
-
-import org.apache.spark.{HashPartitioner, Partitioner, RangePartitioner}
+import org.apache.spark.{HashPartitioner, Partitioner}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.storage.StorageLevel
+import org.apache.spark.sql.functions.{col, expr, udf}
 import org.locationtech.jts.geom.TopologyException
-import org.locationtech.jts.operation.union.{CascadedPolygonUnion, UnaryUnionOp}
-
-import spire.syntax.cfor._
-
+import org.locationtech.jts.operation.union.CascadedPolygonUnion
 import org.log4s._
+import spire.syntax.cfor._
+import vectorpipe.VectorPipe
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.util.control.NonFatal
-import scala.concurrent.{Await, Future}
-
 import java.net.URI
-
 
 /**
   * Here we're going to start from country mbtiles and then do ranged reads
@@ -121,6 +114,57 @@ class PopulationNearRoadsJob(
       rasterSource.crs, KeyBounds(layout.mapTransform.extentToBounds(rasterSource.extent)))
 
     ContextRDD(rdd, md)
+  }
+
+  def forgottenLayerTiles(outputUri: URI, pixelScale: Int): Unit = {
+    import spark.implicits._
+    val maxZoom = 12
+    val minZoom = 6
+    // Tweak this value by powers of 2 to increase or reduce the pixel size in the output
+    // Higher number == smaller pixels
+    val pixelsPerTile = math.pow(2, pixelScale).toInt
+    val wmLayoutScheme = ZoomedLayoutScheme(WebMercator, pixelsPerTile)
+    val wmLayout: LayoutDefinition = wmLayoutScheme.levelForZoom(maxZoom).layout
+    val latLngToWebMercator = Transform(LatLng, WebMercator)
+
+    val gridPointsRdd: RDD[(Long, Long, Double)] = forgottenLayer.flatMap {
+      case (key: SpatialKey, tile: Tile) => {
+        val tileExtent = key.extent(layout)
+        val re = RasterExtent(tileExtent, tile)
+        for {
+          col <- Iterator.range(0, tile.cols)
+          row <- Iterator.range(0, tile.rows)
+          v = tile.getDouble(col, row)
+          if isData(v)
+        } yield {
+          val (lon, lat) = re.gridToMap(col, row)
+          val point = Point(lon, lat)
+          val wmPoint = point.reproject(latLngToWebMercator)
+          val (x, y) = wmLayout.mapToGrid(wmPoint)
+          (x, y, v)
+        }
+      }
+    }
+
+    val pipeline = ForgottenPopPipeline(
+      "geom",
+      URI.create(s"${outputUri.toString}/x$pixelScale"),
+      wmLayoutScheme,
+      maxZoom
+    )
+    val vpOptions = VectorPipe.Options(
+      maxZoom = maxZoom,
+      minZoom = Some(minZoom),
+      srcCRS = WebMercator,
+      destCRS = None,
+      useCaching = false,
+      orderAreas = false
+    )
+
+    val gridPointsDf = gridPointsRdd
+      .toDF("x", "y", "pop")
+      .withColumn("geom", pipeline.geomUdf(wmLayout)(col("x"), col("y")))
+    VectorPipe(gridPointsDf, pipeline, vpOptions)
   }
 
   lazy val result: (PopulationSummary, StreamingHistogram) =


### PR DESCRIPTION
Geometries in tiles are a polygon grid with a "population" property that sums unserved population within the geometry.

Computed using VectorPipe. Whoop.

Pixel Scale opt allows tweaking the size of the polygon "pixels" in the output layer. The number of polygons per tile is defined as 2 ^ pixelScale per dimension. So pixelScale = 4 would give an output tile with 2 ^ 4 = 16 polygons in both x and y.

Some timings run locally on MacBook Pro 2017 w/ dual core CPU:
- MWI @ pixelScale = 4: 5 mins
- MWI @ pixelScale = 5: 5 mins
- MWI @ pixelScale = 8: 8 mins
- DJI @ pixelScale = 4: 2 mins
- DJI @ pixelScale = 5: 3 mins
- DJI @ pixelScale = 8: 5 mins

I generated test layers for MWI at 4x and 5x, and DJI at 4x - 8x pixelScale, available at:
```
https://un-sdg.s3.amazonaws.com/tiles/forgotten-population/{"DJI"|"MWI"}/x{pixelScale}/{z}/{x}/{y}.mvt
```

The command to generate these layers is:
```
AWS_PROFILE=geotrellis time ./sbt "test:runMain geotrellis.sdg.PopulationNearRoads --country DJI --outputTileLayer s3://un-sdg/tiles/forgotten-population/DJI --pixelScale 4 --output /tmp/DJI-out.json"
```
This command requires that the appropriate MapBox QA tile be downloaded from their site, unzipped, renamed and placed at `/tmp/qatiles/DJI.mbtiles`.

## Demo

This is the DJI layer at pixelScale = 5:

![2019-10-21 14 16 07](https://user-images.githubusercontent.com/1818302/67238810-c4873380-f41b-11e9-9f8b-c150363fb34a.gif)


Closes #16