### PR TITLE
Aggregate source pixels into hex bins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ scalaVersion := "2.11.12"
 organization := "geotrellis"
 
 libraryDependencies ++= Seq(
+  "com.uber" % "h3" % "3.6.0",
   "org.locationtech.geotrellis" %% "geotrellis-vectortile" % "3.0.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-layer" % "3.0.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-s3" % "3.0.0-SNAPSHOT",

--- a/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
+++ b/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
@@ -1,12 +1,17 @@
 package geotrellis.sdg
 
+import collection.JavaConverters._
 import java.net.URI
 
+import com.uber.h3core._
+import com.uber.h3core.util._
 import geotrellis.layer._
-import geotrellis.vector.{Extent, Feature, Geometry, Point}
+import geotrellis.proj4._
+import geotrellis.vector._
 import geotrellis.vectortile.VDouble
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, expr, udf}
+import org.locationtech.jts.geom.Coordinate
 import vectorpipe.vectortile._
 
 /**
@@ -25,42 +30,47 @@ import vectorpipe.vectortile._
   */
 case class ForgottenPopPipeline(geometryColumn: String,
                                 baseOutputURI: URI,
-                                rasterLayoutScheme: ZoomedLayoutScheme,
                                 maxZoom: Int) extends Pipeline {
 
   override val layerMultiplicity: LayerMultiplicity = SingleLayer("data")
 
-  def geomUdf(layout: LayoutDefinition) = udf { (x: Long, y: Long) =>
-    val (xCoord, yCoord) = layout.gridToMap(x, y)
-    Point(xCoord, yCoord)
+  @transient lazy val h3 = H3Core.newInstance
+
+  def geomUdf = udf { (h3Index: String) =>
+    var hexagonCoords = h3
+      .h3ToGeoBoundary(h3Index)
+      .asScala
+      .map { c => new Coordinate(c.lng, c.lat) }
+      .toArray
+    // Add start point to end of coord array, its not included in
+    // h3 output and JTS linear rings expect it.
+    hexagonCoords = hexagonCoords :+ hexagonCoords(0)
+    val polygon = Polygon(hexagonCoords)
+    polygon.reproject(LatLng, WebMercator)
   }
 
   override def reduce(input: DataFrame, layoutLevel: LayoutLevel, keyColumn: String): DataFrame = {
     // Since we call reduce before we generate VT for a layer, skip reduce on first zoom
     val reduceUdf = if (layoutLevel.zoom == maxZoom) {
-      udf { c: Long => c }
+      udf { h3Index: String => h3Index }
     } else {
-      udf { c: Long => c / 2 }
+      udf { h3Index: String =>
+        val zoom = h3.h3GetResolution(h3Index)
+        h3.h3ToParentAddress(h3Index, zoom - 1)
+      }
     }
-    val rasterLayout = rasterLayoutScheme.levelForZoom(layoutLevel.zoom).layout
     input
-      .select("x", "y", "pop")
-      .withColumn("x", reduceUdf(col("x")))
-      .withColumn("y", reduceUdf(col("y")))
-      .groupBy(col("x"), col("y"))
+      .select("h3Index", "pop")
+      .withColumn("h3Index", reduceUdf(col("h3Index")))
+      .groupBy(col("h3Index"))
       .agg(expr("sum(pop) as pop"))
-      .withColumn("geom", geomUdf(rasterLayout)(col("x"), col("y")))
+      .withColumn("geom", geomUdf(col("h3Index")))
       .withColumn(keyColumn, keyTo(layoutLevel.layout)(col("geom")))
   }
 
   override def pack(row: Row, zoom: Int): VectorTileFeature[Geometry] = {
+    val geom = row.getAs[Geometry]("geom")
     val pop = row.getAs[Double]("pop")
-    val center = row.getAs[Point]("geom")
-    val layout = rasterLayoutScheme.levelForZoom(zoom).layout
-    val xDistance = layout.cellSize.width
-    val yDistance = layout.cellSize.height
-    val geom = Extent(center.getX - xDistance / 2, center.getY - yDistance / 2,
-                      center.getX + xDistance / 2, center.getY + yDistance / 2).toPolygon
     Feature(geom, Map("population" -> VDouble(pop)))
   }
 }

--- a/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
+++ b/src/main/scala/geotrellis/sdg/ForgottenPopPipeline.scala
@@ -4,7 +4,6 @@ import collection.JavaConverters._
 import java.net.URI
 
 import com.uber.h3core._
-import com.uber.h3core.util._
 import geotrellis.layer._
 import geotrellis.proj4._
 import geotrellis.vector._
@@ -16,14 +15,11 @@ import vectorpipe.vectortile._
 
 /**
   * VectorPipe Pipeline to sum the population associated with an x/y coordinate
-  * in the rasterLayoutScheme space. It outputs polygons that have the aggregated
+  * in the rasterLayoutScheme space. It outputs hex polygons that have the aggregated
   * value across all geometries under the polygon as a vector tile layer.
   *
   * The vector tile layer in the output is "data" and the population sum is stored
   * in the property "population" of each polygon geometry.
-  *
-  * The size of the output polygons is determined by the tileSize of the passed
-  * rasterLayoutScheme. Larger tileSize == smaller polygon "pixels".
   *
   * This pipeline is fairly generic and could be re-used for any reduction
   * operation over a single value.

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
@@ -44,11 +44,6 @@ object PopulationNearRoads extends CommandApp(
       help = "The URI to which the forgotten pop vector tile layer should be saved. Must be a file or s3 URI").
       orNone
 
-    val tilePixelScaleOpt = Opts.option[Int](
-      long = "pixelScale",
-      help = "Scaling factor for tile pixel size. The higher the number the smaller the pixels.")
-      .withDefault(4)
-
     val partitions = Opts.option[Int]("partitions",
       help = "spark.default.parallelism").
       orNone
@@ -56,8 +51,8 @@ object PopulationNearRoads extends CommandApp(
     // TODO: Add --playbook parameter that allows swapping countries.csv
     // TODO: Add option to save JSON without country borders
 
-    (countryOpt, excludeOpt, outputPath, outputCatalogOpt, outputTileLayerOpt, tilePixelScaleOpt, partitions).mapN {
-      (countriesInclude, excludeCountries, output, outputCatalog, outputTileLayer, tilePixelScale, partitionNum) =>
+    (countryOpt, excludeOpt, outputPath, outputCatalogOpt, outputTileLayerOpt, partitions).mapN {
+      (countriesInclude, excludeCountries, output, outputCatalog, outputTileLayer, partitionNum) =>
 
       System.setSecurityManager(null)
       val conf = new SparkConf()
@@ -105,7 +100,7 @@ object PopulationNearRoads extends CommandApp(
             }
 
             outputTileLayer match {
-              case Some(tileLayerUri) => job.forgottenLayerTiles(tileLayerUri, tilePixelScale)
+              case Some(tileLayerUri) => job.forgottenLayerTiles(tileLayerUri)
               case _ => println("Skipped generating forgotten pop vector tile layer. Use --outputTileLayer to save.")
             }
 

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -13,7 +13,7 @@ import geotrellis.vectortile.VectorTile
 import org.apache.spark.{HashPartitioner, Partitioner}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.{col, expr, udf}
+import org.apache.spark.sql.functions.col
 import org.locationtech.jts.geom.TopologyException
 import org.locationtech.jts.operation.union.CascadedPolygonUnion
 import org.log4s._

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -24,6 +24,8 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import java.net.URI
 
+import com.uber.h3core.H3Core
+
 /**
   * Here we're going to start from country mbtiles and then do ranged reads
   */
@@ -116,19 +118,14 @@ class PopulationNearRoadsJob(
     ContextRDD(rdd, md)
   }
 
-  def forgottenLayerTiles(outputUri: URI, pixelScale: Int): Unit = {
+  def forgottenLayerTiles(outputUri: URI): Unit = {
     import spark.implicits._
-    val maxZoom = 12
+    val maxZoom = 10
     val minZoom = 6
-    // Tweak this value by powers of 2 to increase or reduce the pixel size in the output
-    // Higher number == smaller pixels
-    val pixelsPerTile = math.pow(2, pixelScale).toInt
-    val wmLayoutScheme = ZoomedLayoutScheme(WebMercator, pixelsPerTile)
-    val wmLayout: LayoutDefinition = wmLayoutScheme.levelForZoom(maxZoom).layout
-    val latLngToWebMercator = Transform(LatLng, WebMercator)
 
-    val gridPointsRdd: RDD[(Long, Long, Double)] = forgottenLayer.flatMap {
+    val gridPointsRdd: RDD[(String, Double)] = forgottenLayer.flatMap {
       case (key: SpatialKey, tile: Tile) => {
+        val h3: H3Core = H3Core.newInstance
         val tileExtent = key.extent(layout)
         val re = RasterExtent(tileExtent, tile)
         for {
@@ -138,18 +135,18 @@ class PopulationNearRoadsJob(
           if isData(v)
         } yield {
           val (lon, lat) = re.gridToMap(col, row)
-          val point = Point(lon, lat)
-          val wmPoint = point.reproject(latLngToWebMercator)
-          val (x, y) = wmLayout.mapToGrid(wmPoint)
-          (x, y, v)
+          // Higher number makes larger hexagons
+          // Zero means that our starting maxZoom == h3 hex "resolution"
+          val hexZoomOffset = 1
+          val h3Index = h3.geoToH3Address(lat, lon, maxZoom - hexZoomOffset)
+          (h3Index, v)
         }
       }
     }
 
     val pipeline = ForgottenPopPipeline(
       "geom",
-      URI.create(s"${outputUri.toString}/x$pixelScale"),
-      wmLayoutScheme,
+      outputUri,
       maxZoom
     )
     val vpOptions = VectorPipe.Options(
@@ -162,8 +159,8 @@ class PopulationNearRoadsJob(
     )
 
     val gridPointsDf = gridPointsRdd
-      .toDF("x", "y", "pop")
-      .withColumn("geom", pipeline.geomUdf(wmLayout)(col("x"), col("y")))
+      .toDF("h3Index", "pop")
+      .withColumn("geom", pipeline.geomUdf(col("h3Index")))
     VectorPipe(gridPointsDf, pipeline, vpOptions)
   }
 

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -137,7 +137,7 @@ class PopulationNearRoadsJob(
           val (lon, lat) = re.gridToMap(col, row)
           // Higher number makes larger hexagons
           // Zero means that our starting maxZoom == h3 hex "resolution"
-          val hexZoomOffset = 1
+          val hexZoomOffset = 2
           val h3Index = h3.geoToH3Address(lat, lon, maxZoom - hexZoomOffset)
           (h3Index, v)
         }


### PR DESCRIPTION
Instead of square boxes.

Better matches source cells to their matching
representation on the map. Looks a bit more like
other visualizations too. Simpler, easier to
follow implementation. Reduces artifacts due to
assigning source pixels to buckets unevenly.

Calculation is slightly (< 2x) slower.

Closes #21 

![Screen Shot 2019-10-23 at 5 24 34 PM](https://user-images.githubusercontent.com/1818302/70268330-3ae2b980-176e-11ea-9752-6c24637ec302.png)
