### PR TITLE
Generate road network vector tile layer

### DIFF
--- a/src/main/scala/geotrellis/qatiles/RoadTags.scala
+++ b/src/main/scala/geotrellis/qatiles/RoadTags.scala
@@ -1,9 +1,10 @@
 package geotrellis.qatiles
 
-import geotrellis.vectortile.{VString, Value}
+import geotrellis.vectortile.{VInt64, VString, Value}
 
 /** Container for relevant OSM tags on road features */
-case class RoadTags(highway: Option[String], surface: Option[String]) {
+case class RoadTags(id: Option[Long], highway: Option[String], surface: Option[String]) {
+
   /** Assume road is motor road if not explicitly tagged as foot path */
   def isStrictlyMotorRoad: Boolean = highway match {
     case Some(v) if RoadTags.highwayRoadValues.contains(v) => true
@@ -28,15 +29,23 @@ case class RoadTags(highway: Option[String], surface: Option[String]) {
 object RoadTags {
   def apply(tags: Map[String, Value]): RoadTags = {
     new RoadTags(
+      tags.get("id").collect({ case VInt64(i) => i }),
       tags.get("highway").collect({ case VString(s) => s }),
       tags.get("surface").collect({ case VString(s) => s })
     )
   }
 
+  /** Highway values for client calculations */
+  final val includedValues = Array(
+    "trunk", "primary", "secondary", "tertiary"
+  )
+
   /** Highway values that are motor roads */
   final val highwayRoadValues = Array(
-    "motorway", "trunk", "primary", "secondary", "tertiary", "unclassified",
-    "motorway_link", "trunk_link", "primary_link", "secondary_link", "tertiary_link", "living_street", "service"
+    "trunk", "primary", "secondary", "tertiary",
+    "motorway", "unclassified",
+    "motorway_link", "trunk_link", "primary_link", "secondary_link", "tertiary_link",
+    "living_street", "service"
   )
 
   /** Highway values that presents pedestrian road */

--- a/src/main/scala/geotrellis/sdg/FilteredRoadsPipeline.scala
+++ b/src/main/scala/geotrellis/sdg/FilteredRoadsPipeline.scala
@@ -1,0 +1,40 @@
+package geotrellis.sdg
+
+import java.net.URI
+
+import geotrellis.layer.LayoutLevel
+import geotrellis.vector._
+import geotrellis.vectortile._
+import org.apache.spark.sql.{DataFrame, Row}
+import vectorpipe.vectortile._
+
+case class FilteredRoadsPipeline(geometryColumn: String,
+                                 baseOutputURI: URI,
+                                 reduceToIncludedZoom: Int) extends Pipeline {
+
+  override val layerMultiplicity: LayerMultiplicity = SingleLayer("roads")
+
+  override def reduce(input: DataFrame, layoutLevel: LayoutLevel, keyColumn: String): DataFrame = {
+    if (reduceToIncludedZoom == layoutLevel.zoom) {
+      input.where("isIncluded = true")
+    } else {
+      input
+    }
+  }
+
+  override def pack(row: Row, zoom: Int): VectorTileFeature[Geometry] = {
+    val geom = row.getAs[Geometry]("geom")
+    val osmId = row.getAs[Long]("osmId")
+    val highway = row.getAs[String]("highway")
+    val surface = row.getAs[String]("surface")
+    val isIncluded = row.getAs[Boolean]("isIncluded")
+
+    Feature(geom, Map(
+      "osmId" -> VInt64(osmId),
+      "highway" -> VString(highway),
+      "surface" -> VString(surface),
+      "isIncluded" -> VBool(isIncluded)
+    ))
+  }
+}
+


### PR DESCRIPTION
After a discussion this evening with @rossbernet, the Road network is all  road geoms at max zoom level then, at some chosen zoom, switch to only roads that were used in the mask.

This PR also resolves #22 and updates the mask and road network to filter on the tags requested there.

- Updates CLI params to take tile layer URI
  prefix. We then write forgotten pop
  and road layers to a subdir of the provided
  prefix
- Min/Max zoom are now params to
  PopulationNearRoadsJob. They could be exposed
  to the CLI but aren't currently.
- highway, surface and isIncluded tags are propagated to tile properties
- Update hex bin size `large` -> `small`

## Demo

![Screen Shot 2019-10-23 at 5 24 34 PM](https://user-images.githubusercontent.com/1818302/67435893-26ca6a80-f5bb-11e9-984b-4800a951eb83.png)
![Screen Shot 2019-10-23 at 5 24 44 PM](https://user-images.githubusercontent.com/1818302/67435894-26ca6a80-f5bb-11e9-965e-d96c9a05f295.png)

Closes #22, Closes #15 
