### PR TITLE
Allow users to submit pre-computed rasters

### DIFF
--- a/src/main/scala/geotrellis/qatiles/OsmQaTiles.scala
+++ b/src/main/scala/geotrellis/qatiles/OsmQaTiles.scala
@@ -87,7 +87,7 @@ object OsmQaTiles {
 
   private val activeDownloads: TrieMap[Country, OsmQaTiles] = TrieMap.empty
 
-  def fetchFor(country: Country): OsmQaTiles = activeDownloads.synchronized {
+  def fetchFor(country: CountryLookup): OsmQaTiles = activeDownloads.synchronized {
     activeDownloads.getOrElseUpdate(country, {
       //val sourceUri = OsmQaTiles.uriFromCode(country.code)
       val source = new Path(s"/${country.code}.mbtiles.gz") // default is HDFS root

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
@@ -28,7 +28,7 @@ object PopulationNearRoads extends CommandApp(
   header = "Summarize population within and without 2km of OSM roads",
   main = {
     val countryOpt = Opts.options[Country](long = "country", short = "c",
-      help = "ISO 3 country code to use for input (cf https://unstats.un.org/unsd/tradekb/knowledgebase/country-code)").
+      help = "ISO 3 country code or pre-calculated tif URL to use for input").
       withDefault(Country.all)
 
     val excludeOpt = Opts.options[Country](long = "exclude", short = "x",

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -20,105 +20,31 @@ import org.log4s._
 import spire.syntax.cfor._
 import vectorpipe.VectorPipe
 
+import com.uber.h3core.H3Core
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import java.net.URI
 
-import com.uber.h3core.H3Core
+trait PopulationNearRoadsJob {
+  def result: (PopulationSummary, StreamingHistogram)
+  // layer with counts of people that don't live within 2km of all-weather roads
+  def forgottenLayer: TileLayerRDD[SpatialKey]
+  // RDDs that will need recomputation can registered via persist
+  def persist(): Unit
+  // RDDs that will need recomputation can be deregistered via unpersist
+  def unpersist(): Unit
+}
 
-/**
-  * Here we're going to start from country mbtiles and then do ranged reads
-  */
-class PopulationNearRoadsJob(
-  country: Country,
-  grumpRdd: RDD[Geometry],
-  layout: LayoutDefinition,
-  crs: CRS,
-  roadFilter: RoadTags => Boolean
-)(implicit spark: SparkSession) extends Serializable {
-  import PopulationNearRoadsJob._
+object PopulationNearRoadsJob {
 
   @transient private[this] lazy val logger = getLogger
 
-  @transient lazy val rasterSource = country.rasterSource.reprojectToGrid(crs, layout)
-
-  @transient lazy val layoutTileSource: LayoutTileSource[SpatialKey] =
-    LayoutTileSource.spatial(rasterSource, layout)
-
-  val wsCountryBorder: MultiPolygon = country.boundary.reproject(LatLng, layoutTileSource.source.crs)
-  val countryRdd: RDD[Country] = spark.sparkContext.parallelize(Array(country), 1)
-
-  // Generate per-country COG regions we will need to read.
-  // These do not contain duplicate reads of pixels - each key maps to COG segment
-  val regionsRdd: RDD[(SpatialKey, Unit)] =
-    countryRdd.flatMap({ country =>
-      // WARN: who says these COGs exists there at all (USA does not) ?
-      logger.info(s"Reading: $country ${layoutTileSource.source.name}")
-      layoutTileSource.layout.mapTransform.keysForGeometry(wsCountryBorder).map { key => (key, ())}
-    }).setName(s"${country.code} Regions").cache()
-
-  val partitioner: Partitioner = {
-    val regionCount = regionsRdd.count
-    val partitions = math.max(1, regionCount / 16).toInt
-    logger.info(s"Partitioner: ${country.code} using $partitions partitions for $regionCount regions")
-    //SpatialPartitioner(partitions, bits = 4)
-    new HashPartitioner(partitions)
-  }
-
-  // Each buffered road "overflowed", we need to join it back up, not going to trim it tough
-  val roadMaskRdd: RDD[(SpatialKey, MutableArrayTile)] = {
-    val allKeysRdd = countryRdd.flatMap { country =>
-      val qaTiles = OsmQaTiles.fetchFor(country)
-      qaTiles.allKeys.map { key => (key, Unit) }
-    }.setName(s"${country.code} MBTile Keys").cache()
-
-    allKeysRdd.partitionBy(partitioner).flatMap { case (key, _) =>
-      val qaTiles = OsmQaTiles.fetchFor(country)
-      val row = qaTiles.fetchRow(key).get
-      val roads: Seq[MultiLineString] = extractRoads(row.tile, roadFilter)
-      val buffered = roads.map(GeometryUtils.bufferByMeters(_, WebMercator, layoutTileSource.source.crs, meters = 2000))
-      burnRoadMask(layoutTileSource.layout, buffered)
-    }
-  }.reduceByKey(partitioner, (l, r) => combineMasks(l, r))
-
-  // We have RDD of countries and COG keys we will need to read.
-  // However, there could be pop regions NOT covered by COGs that we still need to read
-  // So we should consider all regions available form WorldPop and join them to vectors
-
-  // TODO: try read and tile approach for performance
-  val grumpMaskRdd: RDD[(SpatialKey, Tile)] =
-    Grump.masksForBoundary(grumpRdd, layout, wsCountryBorder, partitioner)
-      .setName(s"${country.code} GRUMP Mask")
-
-  val popRegions: RDD[(SpatialKey, SummaryRegion)] =
-    regionsRdd.
-      cogroup(roadMaskRdd, grumpMaskRdd, partitioner).
-      flatMap { case (key, (_, roadMasks, grumpMasks)) =>
-        // !!! This part is CRITICAL !!!
-        // We moved the key and not the RasterRegion because each regions will spawn a new RasterSource
-        // This would result in new S3Client and Metadata fetch for EVERY segment read.
-        // So we generate RasterRegion from key inside the map step
-        layoutTileSource.rasterRegionForKey(key).
-          map({ region =>
-            val sm = SummaryRegion(region, roadMasks.headOption, grumpMasks.headOption)
-            (key, sm)
-          })
-      }
-
-  val forgottenLayer: TileLayerRDD[SpatialKey] = {
-    val rdd = popRegions.flatMap { case (key, region) =>
-      region.forgottenPopTile.map(tile => (key, tile))
-    }
-
-    // This is the first time in the job flow we're trying to read COG on driver, log for tracing
-    logger.info(s"Reading COG: ${rasterSource.name}")
-    val md = TileLayerMetadata(rasterSource.cellType, layout, rasterSource.extent,
-      rasterSource.crs, KeyBounds(layout.mapTransform.extentToBounds(rasterSource.extent)))
-
-    ContextRDD(rdd, md)
-  }
-
-  def forgottenLayerTiles(outputUri: URI): Unit = {
+  def forgottenLayerTiles(
+    forgottenLayer: TileLayerRDD[SpatialKey],
+    outputUri: URI,
+    layout: LayoutDefinition
+  )(implicit spark: SparkSession): Unit = {
     import spark.implicits._
     val maxZoom = 10
     val minZoom = 6
@@ -164,87 +90,6 @@ class PopulationNearRoadsJob(
     VectorPipe(gridPointsDf, pipeline, vpOptions)
   }
 
-  lazy val result: (PopulationSummary, StreamingHistogram) =
-    popRegions.flatMap({ case (_, r) =>
-      for {
-        tile: Tile <- r.forgottenPopTile
-        sum <- r.summary
-      } yield {
-        val hist = StreamingHistogram(256)
-        tile.foreachDouble(c => hist.countItem(c, 1))
-        (sum, hist)
-      }
-    }).reduce({ case ((s1, h1), (s2, h2)) => (s1.combine(s2), h1.merge(h2))})
-}
-
-
-object PopulationNearRoadsJob {
-
-  @transient private[this] lazy val logger = getLogger
-
-  /** Error prone process where we do the best we can (deprecated)
-    * TopologyException exceptions happen on union
-    */
-  def unionAndKey(country: Country, geoms: Seq[Geometry], layout: LayoutDefinition): Seq[((Country, SpatialKey), Geometry)] = {
-    try {
-      val unionGeom: Geometry = CascadedPolygonUnion.union(geoms.asJava)
-      val cogRegionKeys = layout.mapTransform.keysForGeometry(unionGeom)
-      cogRegionKeys.map { cogKey =>
-        ((country, cogKey), unionGeom)
-      }
-    } catch {
-      case e: TopologyException =>
-        val single = geoms.maxBy(_.getArea)
-        logger.error(s"TopologyException on union keeping: " + single.toWKT)
-        // we couldn't union them, lets get the one with biggest area
-        val cogRegionKeys = layout.mapTransform.keysForGeometry(single)
-        cogRegionKeys.map { cogKey =>
-          ((country, cogKey), single)
-        }
-    }
-  }.toSeq
-
-  /** Geometries rasterized to masks, tiled by given layout
-   * @note geoms and layout are expected to be in same CRS
-   */
-  def burnRoadMask(layout: LayoutDefinition, geoms: Seq[Geometry]): Seq[(SpatialKey, MutableArrayTile)] = {
-    val options = Rasterizer.Options(includePartial =  false, sampleType = PixelIsPoint)
-    val masks = mutable.HashMap.empty[SpatialKey, MutableArrayTile]
-    val tileCols = layout.tileCols
-    val tileRows = layout.tileRows
-    for {
-      geom <- geoms
-      key <- layout.mapTransform.keysForGeometry(geom)
-      extent = layout.mapTransform.keyToExtent(key)
-      re = RasterExtent(extent, tileCols, tileRows)
-      mask = masks.getOrElseUpdate(key, ArrayTile.empty(BitCellType, tileCols, tileRows))
-    } Rasterizer.foreachCellByGeometry(geom, re, options) { (col, row) => mask.set(col, row, 1)}
-    masks.map({ case (key, mask) => (key, mask)}).toList
-  }
-
-  /** Mutable, burn masks from right to left */
-  def combineMasks(left: MutableArrayTile, right: MutableArrayTile): MutableArrayTile = {
-    cfor(0)(_ < left.cols, _ + 1) { col =>
-      cfor(0)(_ < left.rows, _ + 1) { row =>
-        if (left.get(col, row) == 0)
-          left.set(col, row, right.get(col, row))
-      }
-    }
-    left
-  }
-
-  /** Returns all OSM road ways that match the filter function.
-   * @param tile MapBox OSM VectorTile, assumed to have "osm" layer
-   * @param filter filter function on highway tag and surface tag
-   */
-  def extractRoads(tile: VectorTile, filter: RoadTags => Boolean): Seq[MultiLineString] = {
-    tile.layers("osm").lines.
-      filter(f => filter(RoadTags(f.data))).
-      map(f => MultiLineString(f.geom)) ++
-    tile.layers("osm").multiLines.
-      filter(f => filter(RoadTags(f.data))).
-      map(_.geom)
-  }
   /** Save country as GeoTIFF for inspection
    * @note This method relies on collecting layer tiles to the master.
    *       Don't expect it to work for larger countries.

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsLookupJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsLookupJob.scala
@@ -1,0 +1,264 @@
+package geotrellis.sdg
+
+import geotrellis.layer._
+import geotrellis.proj4._
+import geotrellis.qatiles.{OsmQaTiles, RoadTags}
+import geotrellis.raster.rasterize.Rasterizer
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff.compression.DeflateCompression
+import geotrellis.raster.io.geotiff.{GeoTiffBuilder, GeoTiffOptions, SinglebandGeoTiff, Tags, Tiled}
+import geotrellis.spark.{ContextRDD, TileLayerRDD}
+import geotrellis.vector._
+import geotrellis.vectortile.VectorTile
+
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.{HashPartitioner, Partitioner}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{col, expr, udf}
+
+import org.locationtech.jts.geom.TopologyException
+import org.locationtech.jts.operation.union.CascadedPolygonUnion
+import org.log4s._
+import spire.syntax.cfor._
+import vectorpipe.VectorPipe
+
+import com.uber.h3core.H3Core
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import java.net.URI
+
+/**
+  * Here we're going to start from country mbtiles and then do ranged reads
+  */
+class PopulationNearRoadsLookupJob(
+  country: CountryLookup,
+  grumpRdd: RDD[Geometry],
+  layout: LayoutDefinition,
+  crs: CRS,
+  roadFilter: RoadTags => Boolean
+)(implicit spark: SparkSession) extends PopulationNearRoadsJob with Serializable {
+
+  @transient private[this] lazy val logger = getLogger
+
+  @transient lazy val rasterSource = country.rasterSource.reprojectToGrid(crs, layout)
+
+  @transient lazy val layoutTileSource: LayoutTileSource[SpatialKey] =
+    LayoutTileSource.spatial(rasterSource, layout)
+
+  val wsCountryBorder: MultiPolygon = country.boundary.reproject(LatLng, layoutTileSource.source.crs)
+  val countryRdd: RDD[CountryLookup] = spark.sparkContext.parallelize(Array(country), 1)
+
+  // Generate per-country COG regions we will need to read.
+  // These do not contain duplicate reads of pixels - each key maps to COG segment
+  val regionsRdd: RDD[(SpatialKey, Unit)] =
+    countryRdd.flatMap({ country =>
+      // WARN: who says these COGs exists there at all (USA does not) ?
+      logger.info(s"Reading: $country ${layoutTileSource.source.name}")
+      layoutTileSource.layout.mapTransform.keysForGeometry(wsCountryBorder).map { key => (key, ())}
+    }).setName(s"${country.code} Regions").cache()
+
+  val partitioner: Partitioner = {
+    val regionCount = regionsRdd.count
+    val partitions = math.max(1, regionCount / 16).toInt
+    logger.info(s"Partitioner: ${country.code} using $partitions partitions for $regionCount regions")
+    //SpatialPartitioner(partitions, bits = 4)
+    new HashPartitioner(partitions)
+  }
+
+  // Each buffered road "overflowed", we need to join it back up, not going to trim it tough
+  val roadMaskRdd: RDD[(SpatialKey, MutableArrayTile)] = {
+    val allKeysRdd = countryRdd.flatMap { country =>
+      val qaTiles = OsmQaTiles.fetchFor(country)
+      qaTiles.allKeys.map { key => (key, Unit) }
+    }.setName(s"${country.code} MBTile Keys").cache()
+
+    allKeysRdd.partitionBy(partitioner).flatMap { case (key, _) =>
+      val qaTiles = OsmQaTiles.fetchFor(country)
+      val row = qaTiles.fetchRow(key).get
+      val roads: Seq[MultiLineString] = PopulationNearRoadsLookupJob.extractRoads(row.tile, roadFilter)
+      val buffered = roads.map(GeometryUtils.bufferByMeters(_, WebMercator, layoutTileSource.source.crs, meters = 2000))
+      PopulationNearRoadsLookupJob.burnRoadMask(layoutTileSource.layout, buffered)
+    }
+  }.reduceByKey(partitioner, (l, r) => PopulationNearRoadsLookupJob.combineMasks(l, r))
+
+  // We have RDD of countries and COG keys we will need to read.
+  // However, there could be pop regions NOT covered by COGs that we still need to read
+  // So we should consider all regions available form WorldPop and join them to vectors
+
+  // TODO: try read and tile approach for performance
+  val grumpMaskRdd: RDD[(SpatialKey, Tile)] =
+    Grump.masksForBoundary(grumpRdd, layout, wsCountryBorder, partitioner)
+      .setName(s"${country.code} GRUMP Mask")
+
+  val popRegions: RDD[(SpatialKey, SummaryRegion)] =
+    regionsRdd.
+      cogroup(roadMaskRdd, grumpMaskRdd, partitioner).
+      flatMap { case (key, (_, roadMasks, grumpMasks)) =>
+        // !!! This part is CRITICAL !!!
+        // We moved the key and not the RasterRegion because each regions will spawn a new RasterSource
+        // This would result in new S3Client and Metadata fetch for EVERY segment read.
+        // So we generate RasterRegion from key inside the map step
+        layoutTileSource.rasterRegionForKey(key).
+          map({ region =>
+            val sm = SummaryRegion(region, roadMasks.headOption, grumpMasks.headOption)
+            (key, sm)
+          })
+      }
+
+  val forgottenLayer: TileLayerRDD[SpatialKey] = {
+    val rdd = popRegions.flatMap { case (key, region) =>
+      region.forgottenPopTile.map(tile => (key, tile))
+    }
+
+    // This is the first time in the job flow we're trying to read COG on driver, log for tracing
+    logger.info(s"Reading COG: ${rasterSource.name}")
+    val md = TileLayerMetadata(rasterSource.cellType, layout, rasterSource.extent,
+      rasterSource.crs, KeyBounds(layout.mapTransform.extentToBounds(rasterSource.extent)))
+
+    ContextRDD(rdd, md)
+  }
+
+  def forgottenLayerTiles(outputUri: URI, pixelScale: Int): Unit = {
+    import spark.implicits._
+    val maxZoom = 12
+    val minZoom = 6
+    // Tweak this value by powers of 2 to increase or reduce the pixel size in the output
+    // Higher number == smaller pixels
+    val pixelsPerTile = math.pow(2, pixelScale).toInt
+    val wmLayoutScheme = ZoomedLayoutScheme(WebMercator, pixelsPerTile)
+    val wmLayout: LayoutDefinition = wmLayoutScheme.levelForZoom(maxZoom).layout
+    val latLngToWebMercator = Transform(LatLng, WebMercator)
+
+    val gridPointsRdd: RDD[(Long, Long, Double)] = forgottenLayer.flatMap {
+      case (key: SpatialKey, tile: Tile) => {
+        val h3: H3Core = H3Core.newInstance
+        val tileExtent = key.extent(layout)
+        val re = RasterExtent(tileExtent, tile)
+        for {
+          col <- Iterator.range(0, tile.cols)
+          row <- Iterator.range(0, tile.rows)
+          v = tile.getDouble(col, row)
+          if isData(v)
+        } yield {
+          val (lon, lat) = re.gridToMap(col, row)
+          val point = Point(lon, lat)
+          val wmPoint = point.reproject(latLngToWebMercator)
+          val (x, y) = wmLayout.mapToGrid(wmPoint)
+          (x, y, v)
+        }
+      }
+    }
+
+    val pipeline = ForgottenPopPipeline(
+      "geom",
+      URI.create(s"${outputUri.toString}/x$pixelScale"),
+      maxZoom
+    )
+    val vpOptions = VectorPipe.Options(
+      maxZoom = maxZoom,
+      minZoom = Some(minZoom),
+      srcCRS = WebMercator,
+      destCRS = None,
+      useCaching = false,
+      orderAreas = false
+    )
+
+    val gridPointsDf = gridPointsRdd
+      .toDF("x", "y", "pop")
+      .withColumn("geom", pipeline.geomUdf(col("h3Index")))
+    VectorPipe(gridPointsDf, pipeline, vpOptions)
+  }
+
+  def persist: Unit = {
+    grumpMaskRdd.persist(StorageLevel.MEMORY_AND_DISK_SER)
+    forgottenLayer.persist(StorageLevel.MEMORY_AND_DISK_SER)
+  }
+
+  def unpersist: Unit = {
+    forgottenLayer.unpersist()
+    grumpMaskRdd.unpersist()
+  }
+
+  lazy val result: (PopulationSummary, StreamingHistogram) =
+    popRegions.flatMap({ case (_, r) =>
+      for {
+        tile: Tile <- r.forgottenPopTile
+        sum <- r.summary
+      } yield {
+        val hist = StreamingHistogram(256)
+        tile.foreachDouble(c => hist.countItem(c, 1))
+        (sum, hist)
+      }
+    }).reduce({ case ((s1, h1), (s2, h2)) => (s1.combine(s2), h1.merge(h2))})
+}
+
+object PopulationNearRoadsLookupJob {
+
+  @transient private[this] lazy val logger = getLogger
+
+  /** Error prone process where we do the best we can (deprecated)
+   * TopologyException exceptions happen on union
+   */
+  def unionAndKey(country: Country, geoms: Seq[Geometry], layout: LayoutDefinition): Seq[((Country, SpatialKey), Geometry)] = {
+    try {
+      val unionGeom: Geometry = CascadedPolygonUnion.union(geoms.asJava)
+      val cogRegionKeys = layout.mapTransform.keysForGeometry(unionGeom)
+      cogRegionKeys.map { cogKey =>
+        ((country, cogKey), unionGeom)
+      }
+    } catch {
+      case e: TopologyException =>
+        val single = geoms.maxBy(_.getArea)
+        logger.error(s"TopologyException on union keeping: " + single.toWKT)
+        // we couldn't union them, lets get the one with biggest area
+        val cogRegionKeys = layout.mapTransform.keysForGeometry(single)
+        cogRegionKeys.map { cogKey =>
+          ((country, cogKey), single)
+        }
+    }
+  }.toSeq
+
+  /** Geometries rasterized to masks, tiled by given layout
+   * @note geoms and layout are expected to be in same CRS
+   */
+  def burnRoadMask(layout: LayoutDefinition, geoms: Seq[Geometry]): Seq[(SpatialKey, MutableArrayTile)] = {
+    val options = Rasterizer.Options(includePartial =  false, sampleType = PixelIsPoint)
+    val masks = mutable.HashMap.empty[SpatialKey, MutableArrayTile]
+    val tileCols = layout.tileCols
+    val tileRows = layout.tileRows
+    for {
+      geom <- geoms
+      key <- layout.mapTransform.keysForGeometry(geom)
+      extent = layout.mapTransform.keyToExtent(key)
+      re = RasterExtent(extent, tileCols, tileRows)
+      mask = masks.getOrElseUpdate(key, ArrayTile.empty(BitCellType, tileCols, tileRows))
+    } Rasterizer.foreachCellByGeometry(geom, re, options) { (col, row) => mask.set(col, row, 1)}
+    masks.map({ case (key, mask) => (key, mask)}).toList
+  }
+
+  /** Mutable, burn masks from right to left */
+  def combineMasks(left: MutableArrayTile, right: MutableArrayTile): MutableArrayTile = {
+    cfor(0)(_ < left.cols, _ + 1) { col =>
+      cfor(0)(_ < left.rows, _ + 1) { row =>
+        if (left.get(col, row) == 0)
+          left.set(col, row, right.get(col, row))
+      }
+    }
+    left
+  }
+
+  /** Returns all OSM road ways that match the filter function.
+   * @param tile MapBox OSM VectorTile, assumed to have "osm" layer
+   * @param filter filter function on highway tag and surface tag
+   */
+  def extractRoads(tile: VectorTile, filter: RoadTags => Boolean): Seq[MultiLineString] = {
+    tile.layers("osm").lines.
+      filter(f => filter(RoadTags(f.data))).
+      map(f => MultiLineString(f.geom)) ++
+    tile.layers("osm").multiLines.
+      filter(f => filter(RoadTags(f.data))).
+      map(_.geom)
+  }
+}

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsProvidedJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsProvidedJob.scala
@@ -25,8 +25,8 @@ import scala.collection.mutable
 import java.net.URI
 
 /**
-  * Here we're going to start from country mbtiles and then do ranged reads
-  */
+ * for running operations on a pre-calculated tif
+ */
 class PopulationNearRoadsProvidedJob(
   countryProvided: CountryProvided,
   layout: LayoutDefinition,

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsProvidedJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsProvidedJob.scala
@@ -1,0 +1,105 @@
+package geotrellis.sdg
+
+import geotrellis.layer._
+import geotrellis.proj4._
+import geotrellis.qatiles.{OsmQaTiles, RoadTags}
+import geotrellis.raster.rasterize.Rasterizer
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff.compression.DeflateCompression
+import geotrellis.raster.io.geotiff.{GeoTiffBuilder, GeoTiffOptions, SinglebandGeoTiff, Tags, Tiled}
+import geotrellis.spark.{ContextRDD, TileLayerRDD}
+import geotrellis.vector._
+import geotrellis.vectortile.VectorTile
+import org.apache.spark.{HashPartitioner, Partitioner}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{col, expr, udf}
+import org.locationtech.jts.geom.TopologyException
+import org.locationtech.jts.operation.union.CascadedPolygonUnion
+import org.log4s._
+import spire.syntax.cfor._
+import vectorpipe.VectorPipe
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import java.net.URI
+
+/**
+  * Here we're going to start from country mbtiles and then do ranged reads
+  */
+class PopulationNearRoadsProvidedJob(
+  countryProvided: CountryProvided,
+  layout: LayoutDefinition,
+  crs: CRS
+)(implicit spark: SparkSession) extends PopulationNearRoadsJob with Serializable {
+
+  @transient private[this] lazy val logger = getLogger
+
+  @transient lazy val rasterSource = countryProvided.rasterSource.reprojectToGrid(crs, layout)
+
+  @transient lazy val layoutTileSource: LayoutTileSource[SpatialKey] =
+    LayoutTileSource.spatial(rasterSource, layout)
+
+  val wsCountryBorder: MultiPolygon =
+    countryProvided.boundary.reproject(rasterSource.crs, layoutTileSource.source.crs)
+
+  val rsRdd: RDD[RasterSource] = spark.sparkContext.parallelize(Array(rasterSource), 1)
+
+  // Generate per-country COG regions we will need to read.
+  // These do not contain duplicate reads of pixels - each key maps to COG segment
+  val regionsRdd: RDD[(SpatialKey, Unit)] = {
+    val regions = layoutTileSource.layout.mapTransform.keysForGeometry(wsCountryBorder).map({ key => (key, ())})
+    spark.sparkContext
+      .parallelize(regions.toSeq, 1)
+      .setName(s"Provided RasterSource Regions")
+      .cache()
+  }
+
+  val partitioner: Partitioner = {
+    val regionCount = regionsRdd.count
+    val partitions = math.max(1, regionCount / 16).toInt
+    logger.info(s"Partitioner: ProvidedImage using $partitions partitions for $regionCount regions")
+    //SpatialPartitioner(partitions, bits = 4)
+    new HashPartitioner(partitions)
+  }
+
+  def popRegions: RDD[(SpatialKey, SummaryRegion)] =
+    regionsRdd.flatMap { case (key, _) =>
+        // !!! This part is CRITICAL !!!
+        // We moved the key and not the RasterRegion because each regions will spawn a new RasterSource
+        // This would result in new S3Client and Metadata fetch for EVERY segment read.
+        // So we generate RasterRegion from key inside the map step
+        layoutTileSource.rasterRegionForKey(key).map({ region =>
+          (key, SummaryRegion(region, None, None))
+        })
+      }
+
+  val forgottenLayer: TileLayerRDD[SpatialKey] = {
+    val rdd = popRegions.flatMap { case (key, region) =>
+      region.forgottenPopTile.map(tile => (key, tile))
+    }
+
+    // This is the first time in the job flow we're trying to read COG on driver, log for tracing
+    logger.info(s"Reading COG: ${rasterSource.name}")
+    val md = TileLayerMetadata(rasterSource.cellType, layout, rasterSource.extent,
+      rasterSource.crs, KeyBounds(layout.mapTransform.extentToBounds(rasterSource.extent)))
+
+    ContextRDD(rdd, md)
+  }
+
+  def persist: Unit = ()
+
+  def unpersist: Unit = ()
+
+  val result: (PopulationSummary, StreamingHistogram) =
+    popRegions.flatMap({ case (_, r) =>
+      for {
+        tile: Tile <- r.forgottenPopTile
+        sum <- r.summary
+      } yield {
+        val hist = StreamingHistogram(256)
+        tile.foreachDouble(c => hist.countItem(c, 1))
+        (sum, hist)
+      }
+    }).reduce({ case ((s1, h1), (s2, h2)) => (s1.combine(s2), h1.merge(h2))})
+}

--- a/src/test/scala/geotrellis/sdg/GrumpSpec.scala
+++ b/src/test/scala/geotrellis/sdg/GrumpSpec.scala
@@ -23,7 +23,7 @@ class GrumpSpec extends WordSpec with Matchers with TestEnvironment {
       }
 
       "read masks as RDD[(SpatialKey, Tile]) for country" in {
-        val mwiBorder = Country.fromCode("MWI").get.boundary
+        val mwiBorder = Country.lookupFromCode("MWI").get.boundary
         val scheme = ZoomedLayoutScheme(LatLng, 1024)
         val layout = scheme.levelForZoom(6).layout
         val rdd = grump.queryAsMaskRdd(mwiBorder, layout, new HashPartitioner(16))


### PR DESCRIPTION
There are two use cases for generating vector tile outputs: 1. looking up population data and road network information based on ISO3 country codes to generate disconnected population estimates and 2. generating vector tiles from pre-computed rasters. To this end, the Country type now has the subtypes CountryLookup and CountryProvided. There are now two different job classes (unified by the trait PopulationNearRoadsJob) which handle divergent logic.

Because the same processing job handles both cases, it should be possible to define processing workloads that queue work for the lookup and provided paths with no extra effort.

Demo:
These tifs should be almost identical (modulo reprojection/resampling effects)
Command:
```
sbt "test:runMain geotrellis.sdg.PopulationNearRoads --country {path_to_tif}/mwi_p_00_3.tif --output /tmp/mwi-provided-out.json --outputTileLayer /tmp/malawi-provided-vt/"
```
Before tif (precalculated data from the data analytics team):
![image](https://user-images.githubusercontent.com/1977405/67439882-92b1d080-f5c5-11e9-94f8-e67b91155b25.png)

After tif (output after reprojection/distribution via spark):
![image](https://user-images.githubusercontent.com/1977405/67439871-888fd200-f5c5-11e9-817f-465768f65a1d.png)

