### PR TITLE
Render raster image pyramid for forgotten pop

### DIFF
--- a/src/main/scala/geotrellis/sdg/OutputProperties.scala
+++ b/src/main/scala/geotrellis/sdg/OutputProperties.scala
@@ -9,14 +9,15 @@ case class OutputProperties(
   pop_urban: Double,
   pop_rural: Double,
   pop_served: Double,
-  pct_served: Double
+  pct_served: Double,
+  breaks: Array[Double]
 )
 
 object OutputProperties {
   implicit val fooDecoder: Decoder[OutputProperties] = deriveDecoder[OutputProperties]
   implicit val fooEncoder: Encoder[OutputProperties] = deriveEncoder[OutputProperties]
 
-  def apply(country: Country, summary: PopulationSummary): OutputProperties =
+  def apply(country: Country, summary: PopulationSummary, breaks: Array[Double]): OutputProperties =
     new OutputProperties(
       code = country.code,
       name = country.name,
@@ -24,6 +25,7 @@ object OutputProperties {
       pop_urban = summary.urban,
       pop_rural = summary.rural,
       pop_served = summary.ruralServed,
-      pct_served = (summary.ruralServed / summary.rural)
+      pct_served = (summary.ruralServed / summary.rural),
+      breaks = breaks
     )
 }

--- a/src/main/scala/geotrellis/sdg/OutputPyramid.scala
+++ b/src/main/scala/geotrellis/sdg/OutputPyramid.scala
@@ -8,7 +8,6 @@ import geotrellis.spark._
 import geotrellis.raster._
 import geotrellis.layer._
 import geotrellis.proj4.WebMercator
-import geotrellis.raster.render.ColorRamp
 import geotrellis.raster.resample.Sum
 import geotrellis.spark.store.LayerWriter
 import geotrellis.spark.store.hadoop.SaveToHadoop
@@ -19,6 +18,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import vectorpipe.VectorPipe
 
 
@@ -48,7 +48,9 @@ object OutputPyramid {
 
       val keyToPath = { k: SpatialKey => s"${outputPath}/${zoom}/${k.col}/${k.row}.png" }
       if (outputPath.startsWith("s3")) {
-        SaveToS3(imageRdd, keyToPath)
+        SaveToS3(imageRdd, keyToPath, { request =>
+          request.toBuilder.acl(ObjectCannedACL.PUBLIC_READ).build()
+        })
       } else {
         SaveToHadoop(imageRdd, keyToPath)
       }

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
@@ -88,7 +88,7 @@ object PopulationNearRoads extends CommandApp(
             val layout = LayoutDefinition(rasterSource.gridExtent, 256)
 
             val job = new PopulationNearRoadsJob(country, grumpRdd, layout, LatLng,
-              { t => RoadTags.includedValues.contains(t.highway) },
+              { t => RoadTags.includedValues.contains(t.highway.getOrElse("")) },
               maxZoom = 10,
               minZoom = 6)
 

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -32,9 +32,7 @@ class PopulationNearRoadsJob(
   grumpRdd: RDD[Geometry],
   layout: LayoutDefinition,
   crs: CRS,
-  roadFilter: RoadTags => Boolean,
-  maxZoom: Int,
-  minZoom: Int
+  roadFilter: RoadTags => Boolean
 )(implicit spark: SparkSession) extends Serializable {
   import PopulationNearRoadsJob._
 
@@ -130,7 +128,7 @@ class PopulationNearRoadsJob(
     ContextRDD(rdd, md)
   }
 
-  def roadLayerTiles(outputUri: URI): Unit = {
+  def roadLayerTiles(outputUri: URI, maxZoom: Int, minZoom: Int): Unit = {
     import spark.implicits._
 
     val filteredRoadsWithTagsRdd: RDD[(SpatialKey, MultiLineString, Long, String, String, Boolean)] =

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -1,5 +1,7 @@
 package geotrellis.sdg
 
+import java.net.URI
+
 import geotrellis.layer._
 import geotrellis.proj4._
 import geotrellis.qatiles.{OsmQaTiles, RoadTags}
@@ -13,7 +15,6 @@ import geotrellis.vectortile.VectorTile
 import org.apache.spark.{HashPartitioner, Partitioner}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.{col, udf}
 import org.locationtech.jts.geom.TopologyException
 import org.locationtech.jts.operation.union.CascadedPolygonUnion
 import org.log4s._
@@ -22,9 +23,6 @@ import vectorpipe.VectorPipe
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import java.net.URI
-
-import com.uber.h3core.H3Core
 
 /**
   * Here we're going to start from country mbtiles and then do ranged reads
@@ -161,49 +159,6 @@ class PopulationNearRoadsJob(
     )
 
     VectorPipe(filteredRoadsWithTagsDf, pipeline, vpOptions)
-  }
-
-  def forgottenLayerTiles(outputUri: URI): Unit = {
-    import spark.implicits._
-    val gridPointsRdd: RDD[(String, Double)] = forgottenLayer.flatMap {
-      case (key: SpatialKey, tile: Tile) => {
-        val h3: H3Core = H3Core.newInstance
-        val tileExtent = key.extent(layout)
-        val re = RasterExtent(tileExtent, tile)
-        for {
-          col <- Iterator.range(0, tile.cols)
-          row <- Iterator.range(0, tile.rows)
-          v = tile.getDouble(col, row)
-          if isData(v)
-        } yield {
-          val (lon, lat) = re.gridToMap(col, row)
-          // Higher number makes larger hexagons
-          // Zero means that our starting maxZoom == h3 hex "resolution"
-          val hexZoomOffset = 0
-          val h3Index = h3.geoToH3Address(lat, lon, maxZoom - hexZoomOffset)
-          (h3Index, v)
-        }
-      }
-    }
-
-    val pipeline = ForgottenPopPipeline(
-      "geom",
-      outputUri,
-      maxZoom
-    )
-    val vpOptions = VectorPipe.Options(
-      maxZoom = maxZoom,
-      minZoom = Some(minZoom),
-      srcCRS = WebMercator,
-      destCRS = None,
-      useCaching = false,
-      orderAreas = false
-    )
-
-    val gridPointsDf = gridPointsRdd
-      .toDF("h3Index", "pop")
-      .withColumn("geom", pipeline.geomUdf(col("h3Index")))
-    VectorPipe(gridPointsDf, pipeline, vpOptions)
   }
 
   lazy val result: (PopulationSummary, StreamingHistogram) =

--- a/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
+++ b/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
@@ -1,0 +1,22 @@
+package geotrellis.sdg
+
+import geotrellis.raster.{ColorMap, ColorRamp, Histogram}
+
+object SDGColorMaps {
+  // Ramp provided by Jeff to match current vector tile ramp in use
+  val orange = ColorRamp(
+    0xffffd4ff,
+    0xfed98eff,
+    0xfe9929ff,
+    0xd95f0eff,
+    0x993404ff
+  )
+
+  def forgottenPop(histogram: Histogram[Double]): (ColorMap, Array[Double]) = {
+    val Some((min, max)) = histogram.minMaxValues()
+    val width = (max - min) / orange.numStops
+    val middleBreaks = (1 to orange.numStops).map { v => v * width }
+    val breaks = middleBreaks :+ max
+    (orange.toColorMap(breaks.toArray), (min +: breaks).toArray)
+  }
+}

--- a/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
+++ b/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
@@ -1,10 +1,13 @@
 package geotrellis.sdg
 
-import geotrellis.raster.{ColorMap, ColorRamp, Histogram}
+import geotrellis.raster._
+import geotrellis.raster.render.{ClassBoundaryType, GreaterThan, LessThanOrEqualTo}
 
 object SDGColorMaps {
+
+  val MAX_WORLD_POP_PIXEL_VALUE = 27803
   // Ramp provided by Jeff to match current vector tile ramp in use
-  val orange = ColorRamp(
+  val orange5 = ColorRamp(
     0xffffd4ff,
     0xfed98eff,
     0xfe9929ff,
@@ -12,11 +15,44 @@ object SDGColorMaps {
     0x993404ff
   )
 
+  val orange9 = ColorRamp(
+    0xfff5ebff,
+    0xfee6ceff,
+    0xfdd0a2ff,
+    0xfdae6bff,
+    0xfd8d3cff,
+    0xf16913ff,
+    0xd94801ff,
+    0xa63603ff,
+    0x7f2704ff
+  )
+
   def forgottenPop(histogram: Histogram[Double]): (ColorMap, Array[Double]) = {
-    val Some((min, max)) = histogram.minMaxValues()
-    val width = (max - min) / orange.numStops
-    val middleBreaks = (1 to orange.numStops).map { v => v * width }
-    val breaks = middleBreaks :+ max
-    (orange.toColorMap(breaks.toArray), (min +: breaks).toArray)
+    val ramp = orange9
+    val Some((min, max)) = histogram.minMaxValues
+    val width = (max - min) / ramp.numStops
+    val linearBreaks = (1 to ramp.numStops - 1).map { v => v * width }.toArray
+
+    println(s"Linear breaks: ${(min +: linearBreaks :+ max).mkString(", ")}")
+
+    // Log scale - conversion from:
+    // https://stackoverflow.com/questions/19472747/convert-linear-scale-to-logarithmic
+    // scale start value based on how many powers of ten the max has to give a consistent
+    // log scale for a zero bounded ramp
+    // The "minus 1" is an offset to attempt to keep the values in the higher breaks to a minimum,
+    // it effectively shifts the scale right to slightly larger low end breaks
+    val logMin = if (min == 0.0) width / math.pow(10, math.floor(math.log10(max)) - 1) else min
+    val x1 = max
+    val x2 = logMin
+    val y1 = max
+    val y2 = logMin
+    val b = math.log(y1/y2) / (x1-x2)
+    val a = y1 / math.exp(b * x1)
+    val breaks = linearBreaks.map { x =>
+      a * math.exp(b * x)
+    } :+ max
+
+    // Include min to fully describe range of values (e.g. for a viz legend)
+    (ramp.toColorMap(breaks), min +: breaks)
   }
 }


### PR DESCRIPTION
Instead of vector pyramid, at client request.

Same color ramp as vector layer, for easier comparison. Uses a linear ramp, histogram breaks introduce a ton of artifacts and push the breaks too far to the low end since the data values are skewed low.

## Demo

https://tilejson.io/g/42a1dda6b1f45c7cd7e9d82936095324/view

![Screen Shot 2019-10-24 at 5 05 00 PM](https://user-images.githubusercontent.com/1818302/67525720-44fa9e00-f681-11e9-98b4-a704b88b7a33.png)


