### PR TITLE
Add color break generation for single global ramp

### DIFF
--- a/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
@@ -108,11 +108,6 @@ object PopulationNearRoads extends CommandApp(
               case Some(tileLayerUri) => {
                 OutputPyramid.savePng(
                   job.forgottenLayer,
-                  perCountryColorMap,
-                  outputPath = s"$tileLayerUri/${country.code}/forgotten-pop"
-                )
-                OutputPyramid.savePng(
-                  job.forgottenLayer,
                   SDGColorMaps.global,
                   outputPath = s"$tileLayerUri/${country.code}/forgotten-pop-global"
                 )

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoads.scala
@@ -93,7 +93,7 @@ object PopulationNearRoads extends CommandApp(
             job.grumpMaskRdd.persist(StorageLevel.MEMORY_AND_DISK_SER)
             job.forgottenLayer.persist(StorageLevel.MEMORY_AND_DISK_SER)
             val (summary, histogram) = job.result
-            val (colorMap, breaks) = SDGColorMaps.forgottenPop(histogram)
+            val (perCountryColorMap, perCountryBreaks) = SDGColorMaps.forgottenPop(histogram)
 
             PopulationNearRoadsJob.layerToGeoTiff(job.forgottenLayer).write(s"/tmp/sdg-${country.code}-all-roads.tif")
 
@@ -102,14 +102,19 @@ object PopulationNearRoads extends CommandApp(
             }
 
             println(s"Histogram: ${histogram.minValue}, ${histogram.maxValue}")
-            println(s"Breaks: ${breaks.mkString(",")}")
+            println(s"Per Country Breaks: ${perCountryBreaks.mkString(",")}")
 
             tileLayerUriPrefix match {
               case Some(tileLayerUri) => {
                 OutputPyramid.savePng(
                   job.forgottenLayer,
-                  colorMap,
+                  perCountryColorMap,
                   outputPath = s"$tileLayerUri/${country.code}/forgotten-pop"
+                )
+                OutputPyramid.savePng(
+                  job.forgottenLayer,
+                  SDGColorMaps.global,
+                  outputPath = s"$tileLayerUri/${country.code}/forgotten-pop-global"
                 )
                 job.roadLayerTiles(
                   URI.create(s"$tileLayerUri/${country.code}/roads"),
@@ -124,7 +129,7 @@ object PopulationNearRoads extends CommandApp(
             job.grumpMaskRdd.unpersist()
 
             spark.sparkContext.clearJobGroup()
-            (country, summary, breaks)
+            (country, summary, perCountryBreaks)
           })
           Await.result(future, scala.concurrent.duration.Duration.Inf)
         }

--- a/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
+++ b/src/main/scala/geotrellis/sdg/SDGColorMaps.scala
@@ -27,13 +27,24 @@ object SDGColorMaps {
     0x7f2704ff
   )
 
+  val globalBreaks = Array(
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    50,
+    100,
+    1000,
+    33000
+  )
+  val global = orange9.toColorMap(globalBreaks)
+
   def forgottenPop(histogram: Histogram[Double]): (ColorMap, Array[Double]) = {
     val ramp = orange9
     val Some((min, max)) = histogram.minMaxValues
     val width = (max - min) / ramp.numStops
     val linearBreaks = (1 to ramp.numStops - 1).map { v => v * width }.toArray
-
-    println(s"Linear breaks: ${(min +: linearBreaks :+ max).mkString(", ")}")
 
     // Log scale - conversion from:
     // https://stackoverflow.com/questions/19472747/convert-linear-scale-to-logarithmic


### PR DESCRIPTION
So that we can compare image layers with scaled ramps
vs a single global one. In the interest of time, there's some copy-pasted shenanigans going on here.

I just had the job generate both ramps at different paths, because it doesn't take significant extra amount of time to generate as far as I can tell, and its likely valuable to have both since there's a large amount of variation between the two.

Compare:

global ramps: https://tilejson.io/g/a860564412d56c84da9af16e50e5d694/view
per-country ramps: https://tilejson.io/g/405416caab22081dbd057aef980afc1c/view
