### PR TITLE
Buffer boundary clipping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ assemblyMergeStrategy in assembly := {
   case _ => MergeStrategy.first
 }
 
-sparkInstanceCount          := 64
+sparkInstanceCount          := 80
 sparkMasterType             := "m4.4xlarge"
 sparkCoreType               := "m4.4xlarge"
 sparkMasterPrice            := Some(1.00)

--- a/src/main/scala/geotrellis/sdg/Grump.scala
+++ b/src/main/scala/geotrellis/sdg/Grump.scala
@@ -97,7 +97,7 @@ object Grump {
   def masksForBoundary(
     rdd: RDD[Geometry],
     layout: LayoutDefinition,
-    boundary: MultiPolygon,
+    boundary: Geometry,
     part: Partitioner
   ): RDD[(SpatialKey, Tile)] = {
     // prepared geometries are not serializable

--- a/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
+++ b/src/main/scala/geotrellis/sdg/PopulationNearRoadsJob.scala
@@ -45,7 +45,11 @@ class PopulationNearRoadsJob(
   @transient lazy val layoutTileSource: LayoutTileSource[SpatialKey] =
     LayoutTileSource.spatial(rasterSource, layout)
 
-  val wsCountryBorder: MultiPolygon = country.boundary.reproject(LatLng, layoutTileSource.source.crs)
+  val wsCountryBorder: Geometry = {
+    // Buffer country border to avoid clipping out tiles where WorldPop and NaturalEarth don't agree on borders
+    val b = 0.833333330000 // ~100km at equator in degrees
+    country.boundary.buffer(b).reproject(LatLng, layoutTileSource.source.crs)
+  }
   val countryRdd: RDD[Country] = spark.sparkContext.parallelize(Array(country), 1)
 
   // Generate per-country COG regions we will need to read.
@@ -54,7 +58,11 @@ class PopulationNearRoadsJob(
     countryRdd.flatMap({ country =>
       // WARN: who says these COGs exists there at all (USA does not) ?
       logger.info(s"Reading: $country ${layoutTileSource.source.name}")
-      layoutTileSource.layout.mapTransform.keysForGeometry(wsCountryBorder).map { key => (key, ())}
+      // Russian and USA rasters have large amount of NODATA regions that we want to clip to save cycles
+      if (country.code == "RUS" || country.code == "USA")
+        layoutTileSource.layout.mapTransform.keysForGeometry(wsCountryBorder).map { key => (key, ())}
+      else
+        layoutTileSource.keys.map(key => (key, ()))
     }).setName(s"${country.code} Regions").cache()
 
   val partitioner: Partitioner = {


### PR DESCRIPTION
Closes: https://github.com/geotrellis/geotrellis-road-distance-sdg/issues/43

For worldpop tiling this PR avoids clipping out the country tiles for all countries except for Russia and USA, which have large NODATA regions and there its a worth while performance optimization.

For other countries like Myanmar we don't need to use this optimization.
<img width="299" alt="Screen Shot 2019-11-19 at 1 34 41 PM" src="https://user-images.githubusercontent.com/1158084/69181833-d8d35480-0add-11ea-833e-a6ed44c06467.png">

The core problem is that WorldPop is much higher resolution than natural earth boundaries. So for instance in this case there are islands off the coast of Myanmar that are not part of the country border in natural earth Admin 0 dataset but is obviously part of WorldPop.

This PR buffers the boundary by 2 degrees in order to capture any such landmasses. Hard to verify if it worked totally but its a generous buffer and it has worked for the three test cases that we have.
